### PR TITLE
Improve chat API streaming test

### DIFF
--- a/tests/api/chat.test.ts
+++ b/tests/api/chat.test.ts
@@ -3,6 +3,9 @@ import handler, { config } from '../../pages/api/chat';
 import OpenAI from 'openai';
 
 describe('/api/chat', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
   it('config disables bodyParser', () => {
     expect(config.api.bodyParser).toBe(false);
   });
@@ -25,7 +28,7 @@ describe('/api/chat', () => {
   it('streams SSE on valid request', async () => {
     // Mock OpenAI streaming
     const fakeStream = {
-      [Symbol.asyncIterator]: function* () {
+      async *[Symbol.asyncIterator]() {
         yield { choices: [{ delta: { content: '{"foo":"bar"}' } }] };
         yield { choices: [{ delta: {} }] };
       }


### PR DESCRIPTION
## Summary
- update SSE test to use async generator for fake stream
- automatically reset jest mocks between tests

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_686b833d7b188329be47ca90fd7bba2e