### PR TITLE
Fix ChatWindow import path

### DIFF
--- a/pages/chat.tsx
+++ b/pages/chat.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from 'react'
 import { useRouter } from 'next/router'
 import InitModal from '../components/InitModal'
-import ChatWindow from '../components/ChatWindow'
+import ChatWindow from '../components/chat/ChatWindow'
 import SubmissionComplete from '../components/chat/SubmissionComplete'
 import { auth } from '../lib/firebase'
 


### PR DESCRIPTION
## Summary
- fix wrong ChatWindow import path in `pages/chat.tsx`

## Testing
- `npm run lint` *(fails: ESLint couldn't find configuration)*
- `npm test` *(fails: jest not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_b_686b833b94d88329a17a97279cfa7a37